### PR TITLE
Adds a Captcha field for guestbook entries

### DIFF
--- a/app/views/guestbook_entries/new.html.haml
+++ b/app/views/guestbook_entries/new.html.haml
@@ -7,17 +7,23 @@
   = form_for :guestbook_entry, url: author_guestbook_entries_path(@author) do |f|
     .form-section
       = f.label "Your message", :class => "label"
-      = f.text_area :text, :class => "field text-input tall"
+      = f.text_area :text, value: @entry&.text, :class => "field text-input tall"
 
     .form-section.mt-10
       = f.label "Your email (optional)", :class => "label"
-      = f.text_field :signer_email, :class => "field text-input"
+      = f.text_field :signer_email, value: @entry&.signer_email, :class => "field text-input"
 
     .form-section.mt-10
       = f.label "Donation info (optional)", :class => "label"
       %div{"style" => "font-size: 14px; opacity: 0.5; margin-bottom: 5px;"}
         If you've made a contribution, feel free to let the author know the method you've used, and the amount.
-      = f.text_area :donation_info, :class => "field text-input mid-tall"
+      = f.text_area :donation_info, value: @entry&.donation_info, :class => "field text-input mid-tall"
+
+    .form-section.mt-10
+      = f.label "Please complete the captcha below", :class => "label"
+      = show_simple_captcha
+      - if @captcha_error
+        %div{"style" => "font-size: 14px; color: #ff5d5d; margin-top: 5px;"} Incorrect image value, please try again
 
     .form-section.mt-20
       = f.submit "Send"


### PR DESCRIPTION
This integrates the simple captcha just as the subscription page has. If failed it will bring you back to guestbook entry form and put an error message below captcha field for you to try again. Also just re-renders the same page so other form field data is retained. 