### PR TITLE
Use --body-text-color for sublabel text color

### DIFF
--- a/app/assets/stylesheets/authors.scss
+++ b/app/assets/stylesheets/authors.scss
@@ -237,7 +237,7 @@
   }
 
   .sublabel {
-    color: rgba(var(--body-text-color), 0.4);
+    color: var(--dimmed-text-color);
     font-size: 12px;
   }
 

--- a/app/assets/stylesheets/authors.scss
+++ b/app/assets/stylesheets/authors.scss
@@ -237,7 +237,7 @@
   }
 
   .sublabel {
-    color: rgba(black, 0.4);
+    color: rgba(var(--body-text-color), 0.4);
     font-size: 12px;
   }
 


### PR DESCRIPTION
When implementing a dark mode for Listed, I noticed that the sublabel text color wasn't using a CSS variable.

This PR adds `var(--body-text-color)` to the sublabel text so that it changes with any theme changes users make.

I have been unable to test this locally, since I couldn't get the Listed project up and running on my machine (I am not a Ruby developer, so I got stuck with some of the Rails install process). 

I have tested it using dev tools in Firefox though and it looks great!
