### PR TITLE
Fix bugs with links

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -41,6 +41,8 @@
     <meta content="<%= @title %>" name="og:title"/>
     <meta content="<%= @title %>" name="og:description"/>
 
+    <base href="<%= root_url %>">
+
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'stylekit', 'data-turbolinks-track': 'reload' %>
 

--- a/client/app/components/authors/Subscribe.jsx
+++ b/client/app/components/authors/Subscribe.jsx
@@ -8,7 +8,7 @@ export default ({ displayAuthor, subscribedToAuthor, subscriptionForAuthor, subs
                 You can follow along with
                 <strong> {displayAuthor.title} </strong>
                 by subscribing to updates via email, or via their{" "}
-                <a href={displayAuthor.rss_url}>RSS feed</a>.
+                <a href={displayAuthor.rss_url} data-turbolinks="false">RSS feed</a>.
             </p>
             <div id="subscription-form" className="form-box">
                 <SubscriptionForm


### PR DESCRIPTION
Two bugs hopefully fixed:
- Added base tag to main application html to indicate the base url for all links. Before this, in some pages when clicking the author's name in the header the target url was not formed properly.
- Disabled turbolinks for the link that directs to the author's RSS feed. Before this, when clicking this link, being directed to the feed and then clicking the back button in the browser, even though the URL changed the page did not reload.