### PR TITLE
Use only to avoid passing author attributes in subscriptions

### DIFF
--- a/app/views/subscriptions/unsubscribe.html.erb
+++ b/app/views/subscriptions/unsubscribe.html.erb
@@ -3,6 +3,7 @@
         only: [],
         include: { 
             author: { 
+                only: [],
                 methods: :title 
             }
         }

--- a/app/views/subscriptions/update_frequency.html.erb
+++ b/app/views/subscriptions/update_frequency.html.erb
@@ -2,7 +2,8 @@
     subscription: @subscription.as_json(
         only: [],
         include: { 
-            author: { 
+            author: {
+                only: [],
                 methods: :title 
             }
         }

--- a/app/views/subscriptions/validate.html.erb
+++ b/app/views/subscriptions/validate.html.erb
@@ -5,6 +5,7 @@
         only: :id,
         include: { 
             author: { 
+                only: [],
                 methods: :title 
             }
         }


### PR DESCRIPTION
Realised I had accidentally omitted using only: [] in as_json for authors in subscription views, which meant all the author's attributes were being passed down to the React component unnecessarily. 