### PR TITLE
Fix older than and newer than links

### DIFF
--- a/app/views/authors/show.html.erb
+++ b/app/views/authors/show.html.erb
@@ -5,5 +5,5 @@
     ),
     olderThan: @older_than,
     newerThan: @newer_than,
-    displayAuthorUrl: @display_author_url
+    displayAuthorUrl: @display_author.url
 }) %>


### PR DESCRIPTION
Fixed prop that I was accidentally passing incorrectly to AuthorShow component which is causing "Older than" and "Newer than" links to be broken. Closes #60 