### PR TITLE
Subscription, custom styles and home url bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ yarn build:dev
 yarn start:dev
 ```
 
-Now the application should be running on http://localhost:3000 and webpack-dev-server should be watching source files and recompiling as you make changes in your code to allow live reloading.
+Now the application should be running on http://localhost:3009 and webpack-dev-server should be watching source files and recompiling as you make changes in your code to allow live reloading.
 
 
 ### How to run locally with Docker

--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -91,6 +91,8 @@ class AuthorsController < ApplicationController
       subscription = Subscription.new author: @display_author, subscriber: @subscriber
       subscription.save
       redirect_to subscription_validate_path({:subscription_id => subscription.id})
+    else
+      redirect_to :back
     end
   end
 

--- a/app/views/authors/_author_header.html.erb
+++ b/app/views/authors/_author_header.html.erb
@@ -1,4 +1,4 @@
-<% home_url = root_path %>
+<% home_url = ENV['HOST'] %>
 <% post = local_assigns[:post] %>
 <% author = @author || @display_author || (post && post.author) %>
 <% private_post = post && post.unlisted %>

--- a/app/views/authors/subscribe.html.erb
+++ b/app/views/authors/subscribe.html.erb
@@ -1,5 +1,7 @@
 <% subscribed_to_author = @subscriber && @subscriber.subscribed_to_author(@display_author) %>
-<% subscription_for_author = @subscriber && @subscriber.subscription_for_author(@display_author) %>
+<% subscription_for_author = @subscriber && @subscriber.subscription_for_author(@display_author).as_json(
+    only: :verified
+) %>
 
 <%= react_component("AuthorSubscribe", props: {
     displayAuthor: @display_author.as_json(

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -53,7 +53,7 @@
     <% end %>
 
     <% if @styles %>
-      <style type="text/css">
+      <style type="text/css" data-turbolinks-track='reload'>
         <%= @styles %>
       </style>
     <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,5 +1,7 @@
 <% subscribed_to_author = @subscriber && @subscriber.subscribed_to_author(@post.author) %>
-<% subscription_for_author = @subscriber && @subscriber.subscription_for_author(@post.author) %>
+<% subscription_for_author = @subscriber && @subscriber.subscription_for_author(@post.author).as_json(
+    only: :verified
+) %>
 
 <%= react_component("PostShow", props: {
     post: @post.as_json(

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<% home_url = root_path %>
+<% home_url = ENV['HOST'] %>
 
 <%= react_component("SharedFooter", props: {
     homeUrl: home_url


### PR DESCRIPTION
Fixes to various bugs I encountered while testing the subscription flow.

- When trying to subscribe to an author using an email for which a subscription already exists, the user didn't get redirected to the captcha screen but instead window.location.href got set to an url that doesn't exist, showing a 404. By adding redirect_to :back if subscription exists, we reload the subscription page with the right message.
- Unnecessary attributes were being passed in the subscriptionForAuthor prop. We only need "verified".
- When accessing a page for an author with custom styling and going back to the homepage, the custom styles remained applied. Added data-turbolinks-track='reload' to the custom styles tag to prevent this behavior.
- When accessing a page for an author with a custom domain, the Listed link in the header was not leading to Listed homepage but to the custom domain. Changed root_path to ENV['HOST'] for this url, which was what was originally being used.
- Fixed port number for localhost in readme file.