### PR TITLE
Fix "Newer" link

### DIFF
--- a/client/app/components/authors/Show.jsx
+++ b/client/app/components/authors/Show.jsx
@@ -18,7 +18,7 @@ export default ({ posts, olderThan, newerThan, displayAuthorUrl }) => {
                     )}
                     {newerThan && (
                         <div className="newer">
-                            <a href={`${displayAuthorUrl}?b=${newerThan}`}> Newer →</a>
+                            <a href={`${displayAuthorUrl}?a=${newerThan}`}> Newer →</a>
                         </div>
                     )}
                 </div>


### PR DESCRIPTION
Fixed link for "Newer" which I was building with b as the query parameter instead of a.