### PR TITLE
Fix subscription success message

### DIFF
--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -86,13 +86,18 @@ class AuthorsController < ApplicationController
     email = params[:email]
     @subscriber = Subscriber.find_or_create_by(email: email)
     session[:subscriber_id] = @subscriber.id
+    subscriptions = Subscription.where(:author => @display_author, :subscriber => @subscriber)
 
-    if Subscription.where(:author => @display_author, :subscriber => @subscriber).count == 0
+    if subscriptions.count == 0
       subscription = Subscription.new author: @display_author, subscriber: @subscriber
       subscription.save
       redirect_to subscription_validate_path({:subscription_id => subscription.id})
     else
-      redirect_to :back
+      if subscriptions.first.verification_sent_at
+        redirect_to :back
+      else
+        redirect_to subscription_validate_path({:subscription_id => subscriptions.first.id})
+      end
     end
   end
 

--- a/app/views/authors/subscribe.html.erb
+++ b/app/views/authors/subscribe.html.erb
@@ -1,6 +1,6 @@
 <% subscribed_to_author = @subscriber && @subscriber.subscribed_to_author(@display_author) %>
 <% subscription_for_author = @subscriber && @subscriber.subscription_for_author(@display_author).as_json(
-    only: :verified
+    only: [:verified, :verification_sent_at]
 ) %>
 
 <%= react_component("AuthorSubscribe", props: {

--- a/client/app/components/authors/SubscriptionForm.jsx
+++ b/client/app/components/authors/SubscriptionForm.jsx
@@ -23,9 +23,9 @@ const SubscriptionForm = ({ subscribedToAuthor, subscriptionForAuthor, subscript
 
     return (
         <div>
-            {subscribedToAuthor ? (
+            {(subscribedToAuthor && subscriptionForAuthor.verification_sent_at) ? (
                 subscriptionSuccess || !subscriptionForAuthor.verified ? (
-                    <div className="sublabel succes">
+                    <div className="sublabel success">
                         <span>Success. Please check your email to confirm your subscription.</span>
                     </div>
                 ) : (


### PR DESCRIPTION
Right now, when a user enters their email to subscribe to an author, a subscription is created in the database. If they don't complete the captcha step afterwards, a verification email is never sent to them, but the subscription form still shows the "Success. Please check your email to confirm your subscription."
With this fix, we only show the success message if the verification email has already been sent. On the controller's side, if a subscription exists, we check if the verification has been sent to either redirect the user to the subscription page and show them the success message (if it has been sent) or redirect them to the captcha (if it hasn't) without creating a new subscription.