### PR TITLE
Fix missing attribute in subscription form

### DIFF
--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,6 +1,6 @@
 <% subscribed_to_author = @subscriber && @subscriber.subscribed_to_author(@post.author) %>
 <% subscription_for_author = @subscriber && @subscriber.subscription_for_author(@post.author).as_json(
-    only: :verified
+    only: [:verified, :verification_sent_at]
 ) %>
 
 <%= react_component("PostShow", props: {


### PR DESCRIPTION
Added verification_sent_at as attribute to be sent for the subscriptionForAuthor prop since it's used for validation in the subscriptionFor component.