### PR TITLE
Fix masonry layout

### DIFF
--- a/client/app/components/usage/active_authors/ActiveAuthors.jsx
+++ b/client/app/components/usage/active_authors/ActiveAuthors.jsx
@@ -1,36 +1,30 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import MasonryLayout from "./MasonryLayout";
 import ActiveAuthorItem from "./ActiveAuthorItem";
 import "./ActiveAuthors.scss";
 
 const ActiveAuthors = ({ activeAuthors }) => {
-    const [authors, setAuthors] = useState(activeAuthors);
+    const easterEggIndex = parseInt(Math.random() * (activeAuthors.length - 1));
+
+    const easterEgg = {
+        id: "easter-egg",
+        title: "This could be you :)",
+        bio: "Share your experience in its truest form. Start writing now.",
+        url: "#",
+        featured: false,
+        easterEgg: true,
+    };
+
+    const authorsPlusEasterEgg = [
+        ...activeAuthors.slice(0, easterEggIndex),
+        easterEgg,
+        ...activeAuthors.slice(easterEggIndex, activeAuthors.length),
+    ];
 
     const getItems = isDesktop =>
-        authors && authors.map(author => (
+        authorsPlusEasterEgg && authorsPlusEasterEgg.map(author => (
             <ActiveAuthorItem key={`${author.id}${isDesktop ? "-desktop" : "-mobile"}`} author={author} />
         ));
-
-    useEffect(() => {
-        const easterEggIndex = parseInt(Math.random() * (activeAuthors.length - 1));
-
-        const easterEgg = {
-            id: "easter-egg",
-            title: "This could be you :)",
-            bio: "Share your experience in its truest form. Start writing now.",
-            url: "#",
-            featured: false,
-            easterEgg: true,
-        };
-
-        const authorsPlusEasterEgg = [
-            ...activeAuthors.slice(0, easterEggIndex),
-            easterEgg,
-            ...activeAuthors.slice(easterEggIndex, activeAuthors.length),
-        ];
-
-        setAuthors(authorsPlusEasterEgg);
-    }, []);
 
     return (
         <div className="active-authors">

--- a/client/app/components/usage/active_authors/ActiveAuthors.scss
+++ b/client/app/components/usage/active_authors/ActiveAuthors.scss
@@ -23,6 +23,10 @@
 }
 
 .active-authors--mobile {
+    .button.card {
+        width: 100%;
+    };
+
     @include Desktop() {
         display: none;
     }


### PR DESCRIPTION
Fixed redesign homepage's masonry layout behaving incorrectly when resizing the screen. Removed the use of useEffect and useState hooks since they were causing a mismatch between the calculated amount of children (authors + easter egg vs just authors) when the component re-rendered.