### PR TITLE
Fix footnotes links

### DIFF
--- a/app/views/authors/_author_header.html.erb
+++ b/app/views/authors/_author_header.html.erb
@@ -13,7 +13,7 @@
     ),
     author: author.as_json(
         only: [:guestbook_disabled, :newsletter_disabled, :bio, :link, :twitter, :header_image_url],
-        methods: [:title, :url_segment, :url, :word_count, :personal_link],
+        methods: [:title, :url, :word_count, :personal_link],
         include: {
             credentials: {
                 only: :id

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -41,8 +41,6 @@
     <meta content="<%= @title %>" name="og:title"/>
     <meta content="<%= @title %>" name="og:description"/>
 
-    <base href="<%= root_url %>">
-
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'stylekit', 'data-turbolinks-track': 'reload' %>
 

--- a/client/app/components/authors/Header.jsx
+++ b/client/app/components/authors/Header.jsx
@@ -12,7 +12,7 @@ export default ({ homeUrl, post, author, privatePost, pages, authorGuestbookEntr
                     </div>
                     {author && !privatePost && (
                         <div className="author-name path-item">
-                            <a href={author.url_segment}>{author.title}</a>
+                            <a href={author.url}>{author.title}</a>
                         </div>
                     )}
                     {post && post.page && (


### PR DESCRIPTION
Removed base url from application layout which was causing the footnotes links to be relative to Listed's homepage url instead of the author or the post's url.
Since I had added this base url previously to fix an issue where the author's title relative link was incorrectly formed, I fixed this by using the author's url for the link instead of the url segment. I think keeping the base url is probably not a good idea since it caused some unexpected behavior such as this one with the footnotes.

Closes #88 