### PR TITLE
Fix typo and header image

### DIFF
--- a/app/assets/stylesheets/authors.scss
+++ b/app/assets/stylesheets/authors.scss
@@ -137,7 +137,8 @@
 
 .header-image {
   display: block;
-  width: 100%;
+  max-width: 100%;
+  margin: auto;
   height: auto;
 }
 

--- a/client/app/components/authors/settings/DeleteBlog.jsx
+++ b/client/app/components/authors/settings/DeleteBlog.jsx
@@ -50,7 +50,7 @@ export default ({ deleteAllDataError, author, authenticityToken }) => {
         <div className="mt-30 form-box full">
             <strong>Delete Blog</strong>
             <p>
-                Delete yout Listed blog and all accompanying data.
+                Delete your Listed blog and all accompanying data.
             </p>
             {deleteAllDataError && (
                 <div className="alert error">


### PR DESCRIPTION
- Fixed typo in Delete blog settings section.
- Changed header image width: 100% to max-width: 100% to prevent small images from stretching.