### PR TITLE
Fix document undefined error

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -72,5 +72,5 @@ production:
   <<: *default
 
   compile: false
-  extract_css: false
+  extract_css: true
   cache_manifest: true


### PR DESCRIPTION
Webpacker production config had extract_css set to false, which meant it was trying to insert the CSS in a style tag in the head of the document, which cannot be done on the server. The line that was causing the problem was this one:

`var style = document.createElement('style');`

By setting this to true, it will extract the CSS in a separate file.