### PR TITLE
Fix scroll position issue

### DIFF
--- a/client/app/components/usage/active_authors/ActiveAuthorItem.jsx
+++ b/client/app/components/usage/active_authors/ActiveAuthorItem.jsx
@@ -23,7 +23,7 @@ const ActiveAuthorItem = ({ author }) => (
             </StartWriting>
         ) : (
             <div className="card">
-                <a href={author.url}>
+                <a href={author.url} data-turbolinks="false">
                     <div className="active-author__title">
                         <h5 className="h5">
                             {author.title}


### PR DESCRIPTION
Fixes #100.

The issue seems to be related to this Turbolinks bug https://github.com/turbolinks/turbolinks/issues/181.

It's only happening with some blogs, and after digging a bit further I discovered it happens on blogs that have some custom style loaded. When loading the custom styles, we are setting data-turbolinks-track to "reload" so that when going to another page (for example, the homepage) from a blog, Turbolinks knows that it should reload the styles asset and the custom style is not preserved. It appears there is an issue with Turbolinks where when using data-turbolinks-track set to "reload", the scroll position is preserved even when transitioning to a different page.

For now, I have disabled Turbolinks on the link that leads to blog pages so that the entire page is loaded without using Turbolinks when clicking on an author, which solves the problem but also means we're not taking profit of Turbolinks advantages for that particular link. We should set it back to true once Turbolinks' bug is fixed.