### PR TITLE
Adjust posts

### DIFF
--- a/client/app/components/posts/Post.jsx
+++ b/client/app/components/posts/Post.jsx
@@ -9,8 +9,8 @@ const Post = ({ truncate, post }) => {
     const previewText = { __html: post.preview_text };
     const renderedText = { __html: post.rendered_text };
 
-    const getTruncatePostContent = () => (
-        <div>
+    const renderTruncatePost = () => (
+        <>
             <div className="post-header">
                 <h5 className="post-title h5">{post.title}</h5>
                 {post.page || (
@@ -23,56 +23,43 @@ const Post = ({ truncate, post }) => {
                 {/* eslint-disable-next-line react/no-danger */}
                 <div className="post-preview-body" dangerouslySetInnerHTML={previewText} />
             </div>
-            <a className="block read-more-link" href={post.author_relative_url}>
-                Read post
-                <SVG src={IcArrowLong} className="read-more-link__icon" />
-            </a>
-        </div>
+            {!post.unlisted && (
+                <a className="block read-more-link" href={post.author_relative_url}>
+                    Read post
+                    <SVG src={IcArrowLong} className="read-more-link__icon" />
+                </a>
+            )}
+        </>
     );
 
-    const renderPost = () => {
-        if (truncate) {
-            return (
-                post.unlisted ? (
-                    getTruncatePostContent()
-                )
-                    : (
-                        <a className="post-title" href={post.author_relative_url}>
-                            {getTruncatePostContent()}
-                        </a>
+    const renderPost = () => (
+        <>
+            <div className="post-header">
+                {post.unlisted ? (
+                    <h2 className="post-title h2">{post.title}</h2>
+                ) : (
+                    !post.page && (
+                        <h2 className="post-title h2">
+                            <a className="post-title" href={post.author_relative_url}>
+                                {post.title}
+                            </a>
+                        </h2>
                     )
-            );
-        }
-
-        return (
-            <>
-                <div className="post-header">
-                    {post.unlisted ? (
-                        <h2 className="post-title h2">{post.title}</h2>
-                    ) : (
-                        !post.page && (
-                            <h2 className="post-title h2">
-                                <a className="post-title" href={post.author_relative_url}>
-                                    {post.title}
-                                </a>
-                            </h2>
-                        )
-                    )}
-                    {post.page || (
-                        <p className="post-date p3">
-                            {`${dayjs(post.created_at).format("MMMM D, YYYY")} · ${post.word_count} words`}
-                        </p>
-                    )}
-                </div>
-                {/* eslint-disable-next-line react/no-danger */}
-                <div className="post-body p1" dangerouslySetInnerHTML={renderedText} />
-            </>
-        );
-    };
+                )}
+                {post.page || (
+                    <p className="post-date p3">
+                        {`${dayjs(post.created_at).format("MMMM D, YYYY")} · ${post.word_count} words`}
+                    </p>
+                )}
+            </div>
+            {/* eslint-disable-next-line react/no-danger */}
+            <div className="post-body p1" dangerouslySetInnerHTML={renderedText} />
+        </>
+    );
 
     return (
         <div className={`post-content ${truncate === true ? "post-preview" : ""}`}>
-            {renderPost()}
+            {truncate ? renderTruncatePost() : renderPost()}
         </div>
     );
 };

--- a/client/app/components/posts/Post.jsx
+++ b/client/app/components/posts/Post.jsx
@@ -15,7 +15,7 @@ const Post = ({ truncate, post }) => {
                 <h5 className="post-title h5">{post.title}</h5>
                 {post.page || (
                     <p className="post-date p3">
-                        {`${dayjs(post.created_at).format("MMMM D, YYYY")} · ${post.word_count} words`}
+                        {`${dayjs(post.created_at).format("MMMM D, YYYY")}`}
                     </p>
                 )}
             </div>
@@ -48,7 +48,7 @@ const Post = ({ truncate, post }) => {
                 )}
                 {post.page || (
                     <p className="post-date p3">
-                        {`${dayjs(post.created_at).format("MMMM D, YYYY")} · ${post.word_count} words`}
+                        {`${dayjs(post.created_at).format("MMMM D, YYYY")}`}
                     </p>
                 )}
             </div>


### PR DESCRIPTION
- On post previews appearing in the "More from..." section below a post, we had a link both for the whole preview div and for the "Read more" link inside it. Since both links were leading to the same place and nested links are forbidden in HTML, I only left the link for the "Read more" link and not for the entire div.
- Removed word count from posts.