### PR TITLE
fix: potential performance enhancements

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -52,7 +52,7 @@
       <%= stylesheet_link_tag    'carded-blog', media: 'all', 'data-turbolinks-track': 'reload' %>
     <% end %>
 
-    <%= stylesheet_packs_with_chunks_tag('clientRegistration', media: 'all', 'data-turbolinks-track': 'reload') %>
+    <%= stylesheet_pack_tag('clientRegistration', media: 'all', 'data-turbolinks-track': 'reload', defer: true) %>
     <%= javascript_packs_with_chunks_tag('clientRegistration', 'data-turbolinks-track': 'reload', defer: true) %>
 
     <% if @display_author %>

--- a/client/app/assets/styles/application.scss
+++ b/client/app/assets/styles/application.scss
@@ -1,22 +1,25 @@
 @font-face {
     font-family: "Merriweather";
-    src: url("../fonts/Merriweather-Bold.ttf") format("truetype");
+    src: local("serif"), url("../fonts/Merriweather-Bold.ttf") format("truetype");
     font-weight: bold;
     font-style: normal;
+    font-display: swap;
 }
 
 @font-face {
     font-family: "Roboto";
-    src: url("../fonts/Roboto-Regular.ttf") format("truetype");
+    src: local("sans-serif"), url("../fonts/Roboto-Regular.ttf") format("truetype");
     font-weight: normal;
     font-style: normal;
+    font-display: swap;
 }
 
 @font-face {
     font-family: "Roboto";
-    src: url("../fonts/Roboto-Bold.ttf") format("truetype");
+    src: local("sans-serif"), url("../fonts/Roboto-Bold.ttf") format("truetype");
     font-weight: bold;
     font-style: normal;
+    font-display: swap;
 }
 
 * {

--- a/config/webpack/client.js
+++ b/config/webpack/client.js
@@ -1,3 +1,12 @@
+const merge = require("webpack-merge");
 const environment = require("./environment");
 
-module.exports = environment;
+const clientConfig = merge(environment.toWebpackConfig(), {
+    output: {
+        filename: "[name].js",
+        chunkFilename: "[name].bundle.js",
+        path: environment.config.output.path,
+    },
+});
+
+module.exports = clientConfig;

--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -1,32 +1,15 @@
 process.env.NODE_ENV = process.env.NODE_ENV || "development";
 
 const merge = require("webpack-merge");
-const clientEnvironment = require("./client");
-const serverConfig = require("./server");
+const client = require("./client");
+const server = require("./server");
 
-clientEnvironment.splitChunks();
-
-const clientConfig = merge(clientEnvironment.toWebpackConfig(), {
+const clientConfig = merge(client, {
     mode: "development",
-    output: {
-        filename: "[name].js",
-        chunkFilename: "[name].bundle.js",
-        path: clientEnvironment.config.output.path,
-    },
-    optimization: {
-        splitChunks: {
-            name: "vendor",
-            cacheGroups: {
-                vendor: {
-                    test: /[\\/]node_modules[\\/]/,
-                    name(module) {
-                        const packageName = module.context.match(/[\\/]node_modules[\\/](.*?)([\\/]|$)/)[1];
-                        return `npm.${packageName.replace("@", "")}`;
-                    },
-                },
-            },
-        },
-    },
+});
+
+const serverConfig = merge(server, {
+    mode: "development",
 });
 
 module.exports = [clientConfig, serverConfig];

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -21,4 +21,17 @@ rules.delete("nodeModules");
 
 ManifestPlugin.options.writeToFileEmit = true;
 
+environment.config.optimization = {
+    splitChunks: {
+        chunks: "all",
+        cacheGroups: {
+            vendor: {
+                test: /[\\/]node_modules[\\/]/,
+                name: "vendor",
+                enforce: true,
+            },
+        },
+    },
+};
+
 module.exports = environment;

--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -1,35 +1,17 @@
 process.env.NODE_ENV = process.env.NODE_ENV || "production";
 
 const merge = require("webpack-merge");
-const clientEnvironment = require("./client");
-const serverConf = require("./server");
+const client = require("./client");
+const server = require("./server");
 
-clientEnvironment.splitChunks();
-
-const clientConfig = merge(clientEnvironment.toWebpackConfig(), {
+const clientConfig = merge(client, {
     mode: "production",
-    output: {
-        filename: "[name].js",
-        chunkFilename: "[name].bundle.js",
-        path: clientEnvironment.config.output.path,
-    },
     optimization: {
-        splitChunks: {
-            name: "vendor",
-            cacheGroups: {
-                vendor: {
-                    test: /[\\/]node_modules[\\/]/,
-                    name(module) {
-                        const packageName = module.context.match(/[\\/]node_modules[\\/](.*?)([\\/]|$)/)[1];
-                        return `npm.${packageName.replace("@", "")}`;
-                    },
-                },
-            },
-        },
+        minimize: true,
     },
 });
 
-const serverConfig = merge(serverConf, {
+const serverConfig = merge(server, {
     mode: "production",
     optimization: {
         minimize: true,

--- a/config/webpack/server.js
+++ b/config/webpack/server.js
@@ -25,9 +25,6 @@ const serverConfig = merge(environment.toWebpackConfig(), {
         path: environment.config.output.path,
         globalObject: "this",
     },
-    optimization: {
-        minimize: false,
-    },
 });
 
 serverConfig.plugins = serverConfig.plugins.filter((plugin) => plugin.constructor.name !== "WebpackAssetsManifest");


### PR DESCRIPTION
- Fiddled a bit with Webpack config, seems I get the best Lighthouse performance results locally when splitting in two bundles, one for our own code and one for all vendor external libraries. However I consistently get a score between 95 and 98 locally, and only up to 87 on the beta environment. Want to test this changes out on beta and see if we get an improvement.
- Improved Webpack config files for better readability and mantainability.
- Added local font sources to display during webfont loading and decrease initial paint time.