### PR TITLE
styles: make content take up remaining height

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,3 +15,14 @@
 
 @import "stylekit";
 @import "rouge";
+
+#main-container {
+  display: flex;
+  min-height: 100%;
+  flex-direction: column;
+}
+
+#content-container {
+  height: 100%;
+  flex: 1;
+}


### PR DESCRIPTION
Before:
<img width="1440" alt="Screen Shot 2021-04-06 at 16 13 53" src="https://user-images.githubusercontent.com/32345857/113765879-34ae7580-96f3-11eb-9e33-b33cf4e54645.png">
Now:
<img width="1440" alt="Screen Shot 2021-04-06 at 16 14 01" src="https://user-images.githubusercontent.com/32345857/113765858-2d876780-96f3-11eb-9e4b-7f69747d2665.png">

🥳