### PR TITLE
fix: show img tag while real svg loads

### DIFF
--- a/client/app/components/authors/HeaderContainer.jsx
+++ b/client/app/components/authors/HeaderContainer.jsx
@@ -38,7 +38,11 @@ const HeaderContainer = ({
                 <div className="left">
                     <div className="website-name">
                         <a href={homeUrl} className="listed-logo-link button button--no-fill" aria-label="Listed logo">
-                            <SVG src={IcListed} className="listed-logo" />
+                            <SVG
+                                src={IcListed}
+                                className="listed-logo"
+                                loader={<img src={IcListed} className="listed-logo" alt="Listed Logo" />}
+                            />
                         </a>
                     </div>
                     {author && !privatePost && (

--- a/client/app/components/authors/HeaderContainer.jsx
+++ b/client/app/components/authors/HeaderContainer.jsx
@@ -40,7 +40,7 @@ const HeaderContainer = ({
                         <a href={homeUrl} className="listed-logo-link button button--no-fill" aria-label="Listed logo">
                             <SVG
                                 src={IcListed}
-                                className="listed-logo"
+                                className="listed-logo listed-logo__animated"
                                 loader={<img src={IcListed} className="listed-logo" alt="Listed Logo" />}
                             />
                         </a>

--- a/client/app/components/authors/HeaderContainer.scss
+++ b/client/app/components/authors/HeaderContainer.scss
@@ -11,10 +11,12 @@
         margin: 0;
         @include MenuHover(var(--header-listed-name));
 
-        svg path {
-            fill: var(--header-listed-name);
+        .listed-logo__animated {
+            path {
+                animation: changeColor linear 1.5s;
+                fill: var(--header-listed-name);
+            }
         }
-
         &::before {
             background-image: none;
         }
@@ -58,6 +60,15 @@
     @include Desktop() {
         height: 36px;
         width: 36px;
+    }
+}
+
+@keyframes changeColor {
+    0% {
+        fill: $color-primary;
+    }
+    100% {
+        fill: var(--header-listed-name);
     }
 }
 


### PR DESCRIPTION
It will show the SVG in black color while the "styled" SVG loads. We need to find out why it's taking so long to load and why it's not being cached
In the meantime, this is a nice fix