### PR TITLE
fix: replace actions/setup-ruby with ruby/setup-ruby

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6
     - uses: actions/cache@v2


### PR DESCRIPTION
Replaces deprecated action [actions/setup-ruby](https://github.com/actions/setup-ruby) with [ruby/setup-ruby](https://github.com/ruby/setup-ruby)

![image](https://user-images.githubusercontent.com/5891646/118281949-c1d7ad80-b49b-11eb-81c0-76bec360bba8.png)